### PR TITLE
chore(actions): bump deprecated GitHub Actions versions

### DIFF
--- a/.github/workflows/bomber.yml
+++ b/.github/workflows/bomber.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     # Checkout Code
     - name: Checkout Code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
 
     # Install Bomber
     - name: Install Bomber
@@ -24,7 +24,7 @@ jobs:
          wget --progress=bar:force:noscroll "https://github.com/devops-kung-fu/bomber/releases/download/v0.4.0/bomber_0.4.0_linux_amd64.deb" && sudo dpkg --install "bomber_0.4.0_linux_amd64.deb"
          bomber -v
     - name: Archive Scan Results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
           name: Archive Scan Results
           path: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Docker login
       env:
         DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}

--- a/.github/workflows/git_commit.yml
+++ b/.github/workflows/git_commit.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Commit files
         run: |

--- a/.github/workflows/jira-tickets-for-new-vulns.yml
+++ b/.github/workflows/jira-tickets-for-new-vulns.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     # Checkout Code
     - name: Checkout Code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
 
     # Install jira-tickets-for-new-vulns
     - name: Install jira-tickets-for-new-vulns

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,9 +20,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       with:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -16,14 +16,14 @@ jobs:
     steps:
     # Checkout Code
     - name: Checkout Code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
 
     # curl SBOM API
     - name: curl SBOM API
       run: |
          curl -X GET "https://api.snyk.io/rest/orgs/0e415b97-149f-46d2-8728-0f9fda933b27/projects/fce0e42a-5df2-4485-9b2f-a460f1383bf3/sbom?version=2022-04-06%7Eexperimental&format=cyclonedx%2Bjson" -H "Accept: application/vnd.api+json" -H "Accept: application/vnd.cyclonedx+json" -H "Authorization: token ${SNYK_TOKEN}" > nodejs-goof_cyclonedx.json
     - name: Archive SBOM
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
           name: Archive SBOM
           path: |

--- a/.github/workflows/snyk-api-import.yml
+++ b/.github/workflows/snyk-api-import.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     # Checkout Code
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Install snyk-api-import
     - name: Install snyk-api-import
@@ -30,7 +30,7 @@ jobs:
          ls
       continue-on-error: true
     - name: snyk-api-import logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
           name: snyk-api-import logs
           path: |

--- a/.github/workflows/snyk-code-manual.yml
+++ b/.github/workflows/snyk-code-manual.yml
@@ -8,9 +8,9 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: sarif.json
           # sarif_file: example111.json

--- a/.github/workflows/snyk-code.yml
+++ b/.github/workflows/snyk-code.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: snyk/actions/setup@master
       - name: Snyk Test
         run: snyk code test --org=${{ secrets.SNYK_ORG }} --sarif > snyk-sarif2.json
@@ -12,6 +12,6 @@ jobs:
         env:
            SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk-sarif2.json

--- a/.github/workflows/snyk-delta.yml
+++ b/.github/workflows/snyk-delta.yml
@@ -8,9 +8,9 @@ jobs:
       matrix:
         node-version: [12.x]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Installing snyk-delta and dependencies

--- a/.github/workflows/snyk-test-sarif.yml
+++ b/.github/workflows/snyk-test-sarif.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: snyk/actions/setup@master
       - name: Snyk Test
         run: snyk test --sarif-file-output=snyk-sarif1.json
@@ -12,6 +12,6 @@ jobs:
         env:
            SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk-sarif1.json

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -9,7 +9,7 @@ jobs:
   snyk_monitor:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
         continue-on-error: true
         uses: snyk/actions@0.3.0
@@ -19,12 +19,12 @@ jobs:
           command: monitor
           args: --remote-repo-url="snyk-schmidtty/nodejs-goof" --project-environment=frontend --project-lifecycle=production --project-business-criticality=high --project-tags=CI=GithubActions,PCI=yes,component=pkg:github/snyk-schmidtty/nodejs-goof@master
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v3
         with:
         # Path to SARIF file relative to the root of the repository
           sarif_file: results.sarif
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Snyk Report
           path: results.html

--- a/.github/workflows/snyk_code.yml
+++ b/.github/workflows/snyk_code.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     # Checkout Code
     - name: Checkout Code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
 
     # Install and Authenticate to Snyk
     - name: Install Snyk & Authenticate
@@ -34,14 +34,14 @@ jobs:
          snyk-to-html -i results_code.sarif -o results_code.html
       continue-on-error: true
     - name: Archive Snyk Scan Results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
           name: Archive Snyk Code Scan Results
           path: | 
             results_code.sarif
             results_code.html  
     - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         # Path to SARIF file relative to the root of the repository
         sarif_file: results_code.sarif

--- a/.github/workflows/snyk_container.yml
+++ b/.github/workflows/snyk_container.yml
@@ -9,7 +9,7 @@ jobs:
   snyk_container:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Build image
       env:
         DOCKER_BUILDKIT: 1
@@ -24,7 +24,7 @@ jobs:
         image: goof-github-actions
         args: --file=Dockerfile
     - name: Upload result to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: snyk.sarif
     - name: Snyk Monitor
@@ -39,7 +39,7 @@ jobs:
   #snyk_monitor:
    # runs-on: ubuntu-latest
     #steps:
-    #- uses: actions/checkout@master
+    #- uses: actions/checkout@v4
     #- name: Run Snyk to check Docker image for vulnerabilities
       #continue-on-error: true
       #uses: snyk/actions/docker@master

--- a/.github/workflows/snyk_delta.yml
+++ b/.github/workflows/snyk_delta.yml
@@ -5,9 +5,9 @@ jobs:
       matrix:
         node-version: [12.x]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Installing snyk-delta and dependencies

--- a/.github/workflows/snyk_iac.yml
+++ b/.github/workflows/snyk_iac.yml
@@ -7,7 +7,7 @@ jobs:
   snyk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run Snyk to check configuration files for security issues
         # Snyk can be used to break the build when it detects security issues.
         # In this case we want to upload the issues to GitHub Code Scanning
@@ -24,6 +24,6 @@ jobs:
           # or `main.tf` for a Terraform configuration file
           file: .
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif

--- a/.github/workflows/snyk_platform.yml
+++ b/.github/workflows/snyk_platform.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     # Checkout Code
     - name: Checkout Code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
 
     # Install and Authenticate to Snyk
     - name: Install Snyk & Authenticate
@@ -34,7 +34,7 @@ jobs:
          snyk container test snykschmidtty/goof:latest --json | snyk-to-html -o results_container.html || true
       continue-on-error: true
     - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         # Path to SARIF file relative to the root of the repository
         sarif_file: results_code.sarif

--- a/.github/workflows/snyk_unmanaged.yml
+++ b/.github/workflows/snyk_unmanaged.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     # Checkout Code
     - name: Checkout Code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
 
     # Install and Authenticate to Snyk
     - name: Install Snyk & Authenticate


### PR DESCRIPTION
Brings every workflow up to currently supported action majors so runs stop auto-failing (e.g. `actions/upload-artifact@v2` hard-deprecation).

## Bumps
- `actions/checkout`: v1/v2/v3/@master → **v4**
- `actions/setup-node`: v1/v2 → **v4**
- `actions/upload-artifact`: v2 → **v4**
- `github/codeql-action/*`: v1/v2 → **v3**

## Left alone
- `snyk/actions/*@master` — floating-master is intentional for this demo repo.
- `snyk/actions@0.3.0` in [snyk.yml](.github/workflows/snyk.yml) — flag for separate bump if desired.

19 workflow files touched, no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)